### PR TITLE
enable soong tests during building

### DIFF
--- a/platforms/arch/BUILD
+++ b/platforms/arch/BUILD
@@ -20,6 +20,11 @@ constraint_value(
     constraint_setting = "@platforms//cpu:cpu",
 )
 
+constraint_value(
+    name = "riscv64",
+    constraint_setting = "@platforms//cpu:cpu",
+)
+
 # Alias to the local_jdk's toolchain constraint to make local_jdk resolve
 # correctly with --tool_java_runtime_version=local_jdk and the checked-in JDK.
 alias(


### PR DESCRIPTION
https://github.com/aosp-riscv/platform_manifest/issues/1

Simply added the new CPU arch RISC-V to arch/BUILD, now it could be able to pass the soong tests part while building AOSP for RISC-V.